### PR TITLE
Update: 手番を切り替えられるようにした。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # tutorials
 
-tutorials
-
 ## USAGE
 
-build : npm run build
+build : npm run build  
 start : npm start

--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,17 @@ class Board extends React.Component {
     super(props);
     this.state = {
       squares: Array(9).fill(null),
+      xIsNext: true,
     };
   }
 
   handleClick(i) {
     const squares = this.state.squares.slice();
-    squares[i] = 'X';
-    this.setState({squares: squares});
+    squares[i] = this.state.xIsNext ? 'X' : 'O'
+    this.setState({
+      squares: squares,
+      xIsNext: !this.state.xIsNext,
+    });
   }
 
   renderSquare(i) {
@@ -38,7 +42,7 @@ class Board extends React.Component {
   }
 
   render() {
-    const status = 'Next player: X';
+    const status = 'Next player:' + (this.state.xIsNext ? 'X' : 'O');
 
     return (
       <div>


### PR DESCRIPTION
手番の区別なく記号がつけられるようになっていた。

プレイヤーとそのときの記号が区別がつかない。
そのため、手番が切り替わるたびに、記号が変化するようにした。
また、次の手番がどちらの記号を担当している人が示すように変更した。