### PR TITLE
Feature: 着手履歴のリストを昇順・降順いずれでも並べかえられるよう、トグルボタンを追加する。

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -19,6 +19,7 @@ export const Game : React.FC = () => {
 
   const [stepNumber, setStepNumber] = useState<number>(0);
   const [xIsNext, setXIsNext] = useState<boolean>(true);
+  const [toggle, setToggle] = useState<boolean>(true);
 
   const handleClick = (i: number) => {
     const _history = history.slice(0, stepNumber + 1);
@@ -68,11 +69,28 @@ export const Game : React.FC = () => {
       </div>
       <div className="game-info">
         <div>{status}</div>
-        <Moves
-          history={history}
-          jumpTo={jumpTo}
-          currentNumber={stepNumber}
-        />
+        <div>
+          <button onClick={() => {setToggle(!toggle)}}>
+            {toggle ? 'Sort descending' : 'Sort ascending'}
+          </button>
+        </div>
+        {
+          toggle ?
+          <ol>
+            <Moves
+              history={history}
+              jumpTo={jumpTo}
+              currentNumber={stepNumber}
+            />
+          </ol> :
+          <ol reversed>
+            <Moves
+              history={history.reverse()}
+              jumpTo={jumpTo}
+              currentNumber={stepNumber}
+            />
+          </ol>
+        }
       </div>
     </div>
   );

--- a/src/components/Moves.tsx
+++ b/src/components/Moves.tsx
@@ -12,19 +12,19 @@ type Props = {
 export const Moves : React.FC<Props> = (props) => {
   const {history,jumpTo,currentNumber} = props;
   return (
-    <ol>
-    {history.map((step, move) => {
-      const desc = move ? `Go to move #${move}.` : 'Go to game start';
-      const location = move ? `(${step.location.col}, ${step.location.row})` : '';
-      return (
-        <li key={move}>
-          <button onClick={() => jumpTo(move)}>
-            {move == currentNumber ? <b>{desc}</b> : desc}
-            {location}
-          </button>
-        </li>
-      );
-    })}
-  </ol>
+    <>
+      {history.map((step, move) => {
+        const desc = move ? `Go to move #${move}.` : 'Go to game start';
+        const location = move ? `(${step.location.col}, ${step.location.row})` : '';
+        return (
+          <li key={move}>
+            <button onClick={() => jumpTo(move)}>
+              {move == currentNumber ? <b>{desc}</b> : desc}
+              {location}
+            </button>
+          </li>
+        );
+      })}
+    </>
   );
 }

--- a/test/components/__snapshots__/Game.test.tsx.snap
+++ b/test/components/__snapshots__/Game.test.tsx.snap
@@ -64,6 +64,13 @@ exports[`ゲームを表現しているコンポーネントの検証 ゲーム�
     <div>
       Next player: X
     </div>
+    <div>
+      <button
+        onClick={[Function]}
+      >
+        Sort descending
+      </button>
+    </div>
     <ol>
       <li>
         <button

--- a/test/components/__snapshots__/Moves.test.tsx.snap
+++ b/test/components/__snapshots__/Moves.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`実行履歴を表現しているコンポーネントの検証 実行履歴が描画されること SnapShotと同一であること 1`] = `<ol />`;
+exports[`実行履歴を表現しているコンポーネントの検証 実行履歴が描画されること SnapShotと同一であること 1`] = `null`;


### PR DESCRIPTION
https://github.com/onesword0618/tutorials/issues/12

トグルボタンを実行すると昇順、降順が入れ替わる