### PR TITLE
Feature: どちらも勝利しなかった場合、結果が引き分けになったというメッセージを表示する。

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -50,11 +50,13 @@ export const Game : React.FC = () => {
   };
 
   const current = history[stepNumber];
-  const gameSet:{ winner:(string | null); line: number[]; } | { winner: null; line: null } = findWinner(current.squares);
+  const gameSet:{ winner:(string | null); line: (number[] | null) } = findWinner(current.squares);
 
   let status:string;
-  if (gameSet.winner) {
+  if (gameSet.winner && gameSet.winner !== 'DRAW') {
     status = 'Winner: ' + gameSet.winner;
+  } else if (gameSet.winner === 'DRAW') {
+    status = 'DRAW';
   } else {
     status = 'Next player: ' + (xIsNext ? 'X' : 'O');
   };

--- a/src/domain/findWinner.ts
+++ b/src/domain/findWinner.ts
@@ -2,7 +2,7 @@
  * 勝利条件の判定をする関数
  * @param {*} squares マス目を模した配列
  */
-export function findWinner(squares:(string | null)[]) : { winner:(string | null); line: number[]; } | { winner: null; line: null } {
+export function findWinner(squares:(string | null)[]) : { winner:(string | null); line: (number[] | null)} {
   const lines = [
     [0, 1, 2],
     [3, 4, 5],
@@ -23,7 +23,15 @@ export function findWinner(squares:(string | null)[]) : { winner:(string | null)
       };
     };
   };
-  return  {
+
+  if(squares.every(square => square)) {
+    return {
+      winner: 'DRAW',
+      line: null,
+    };
+  }
+
+  return {
     winner: null,
     line: null,
   };

--- a/test/domain/findWinner.test.ts
+++ b/test/domain/findWinner.test.ts
@@ -57,4 +57,20 @@ describe('勝利条件として定義した配列の各要素の組み合わせ�
       expect(findWinner(squeres)).toEqual({'line': [2, 4, 6], 'winner': 'X'});
     });
   });
+
+  describe('勝利条件の配列の[2,4,6]を満たしている場合',() => {
+    test('{"line": [2, 4, 6], "winner": "O"}が返却されること',() =>{
+      const squeres:(string | null)[] = [null,null,'O',null,'O',null,'O',null,null];
+      expect(findWinner(squeres)).toEqual({'line': [2, 4, 6], 'winner': 'O'});
+    });
+  });
+});
+
+describe('勝利条件を満たすことができない場合に引き分けの文字列を返却する',() => {
+  describe('勝利条件を満たしていない場合',() => {
+    test('{"line": [2, 4, 6], "winner": "X"}が返却されること',() =>{
+      const squeres:(string | null)[] = ['X','X','O','O','O','X','X','O','X'];
+      expect(findWinner(squeres)).toEqual({'line': null, 'winner': 'DRAW'});
+    });
+  });
 });


### PR DESCRIPTION
https://github.com/onesword0618/tutorials/issues/14

勝利条件を満たさないで盤面が埋まった時に、ステータスにDRAWと表示されること